### PR TITLE
CEW-162: Stripe issues with "pay later" option

### DIFF
--- a/js/civicrm_stripe.js
+++ b/js/civicrm_stripe.js
@@ -157,8 +157,8 @@
 
       // Handle multiple payment options and Stripe not being chosen.
       if ($form.find(".crm-section.payment_processor-section").length > 0) {
-        if ($form.find('input[name="payment_processor_id"]:checked').length) {
-          processorId=$form.find('input[name="payment_processor_id"]:checked').val();
+        if ($form.find('input[name="payment_processor"]:checked').length) {
+          processorId=$form.find('input[name="payment_processor"]:checked').val();
           if (!($form.find('input[name="stripe_token"]').length) || ($('#stripe-id').length && $('#stripe-id').val() != processorId)) {
             return true;
           }
@@ -170,7 +170,7 @@
       }
 
       // Handle pay later (option value '0' in payment_processor radio group).
-      if ($form.find('input[name="payment_processor_id"]:checked').length && !parseInt($form.find('input[name="payment_processor_id"]:checked').val())) {
+      if ($form.find('input[name="payment_processor"]:checked').length && !parseInt($form.find('input[name="payment_processor"]:checked').val())) {
         return true;
       }
 


### PR DESCRIPTION
The stripe JS script was searching for 'payment_processor_id' field when proceeding with 'pay later' transaction. However the payment processor field is named differently ('payment_processor') so the script wasn't able to find the field and terminated stripe flow before stripe token was generated. That was causing "_Stripe.js token was not passed! Report this message to the site administrator_" error.

I've fixed the 'payment_processor' input field name in civicrm_stripe JS script so the stripe JS flow isn't terminated and is able to generate proper stripe token for further use.