### PR TITLE
TT-68: Stripe js token

### DIFF
--- a/js/civicrm_stripe.js
+++ b/js/civicrm_stripe.js
@@ -38,6 +38,24 @@
     }
   }
 
+  /**
+   * Gets Payment Processor input name (may vary depending on CiviCRM version)
+   * within given form.
+   *
+   * @param {object} $form
+   *
+   * @return {string}
+   */
+  function getPaymentProcessorFieldName($form) {
+    var paymentProcessorFieldName = 'payment_processor';
+
+    if ($form.find('input[name="payment_processor_id"]').length) {
+      paymentProcessorFieldName = 'payment_processor_id';
+    }
+
+    return paymentProcessorFieldName;
+  }
+
   // Prepare the form.
   $(document).ready(function() {
     $.getScript('https://js.stripe.com/v2/', function () {
@@ -54,6 +72,12 @@
       }
     }
     $form   = $('form.stripe-payment-form');
+
+    if ($form.find(".crm-section.payment_processor-section").length > 0) {
+      // Mark default payment processor as selected.
+      $form.find('div.payment_processor-section input[checked="checked"]').prop('checked', true);
+    }
+
     if (isWebform) {
       $submit = $form.find('.button-primary');
     }
@@ -155,10 +179,12 @@
         }
       }
 
+      var paymentProcessorFieldName = getPaymentProcessorFieldName($form);
+
       // Handle multiple payment options and Stripe not being chosen.
       if ($form.find(".crm-section.payment_processor-section").length > 0) {
-        if ($form.find('input[name="payment_processor"]:checked').length) {
-          processorId=$form.find('input[name="payment_processor"]:checked').val();
+        if ($form.find('input[name="' + paymentProcessorFieldName + '"]:checked').length) {
+          processorId=$form.find('input[name="' + paymentProcessorFieldName + '"]:checked').val();
           if (!($form.find('input[name="stripe_token"]').length) || ($('#stripe-id').length && $('#stripe-id').val() != processorId)) {
             return true;
           }
@@ -170,7 +196,7 @@
       }
 
       // Handle pay later (option value '0' in payment_processor radio group).
-      if ($form.find('input[name="payment_processor"]:checked').length && !parseInt($form.find('input[name="payment_processor"]:checked').val())) {
+      if ($form.find('input[name="' + paymentProcessorFieldName + '"]:checked').length && !parseInt($form.find('input[name="' + paymentProcessorFieldName + '"]:checked').val())) {
         return true;
       }
 

--- a/stripe.php
+++ b/stripe.php
@@ -186,11 +186,12 @@ function stripe_civicrm_buildForm($formName, &$form) {
  * that processor.
  */
 function stripe_get_key($form) {
-  if (empty($form->_paymentProcessor)) {
-    return;
+  if (!empty($form->_submitValues['stripe_pub_key'])) {
+    return $form->_submitValues['stripe_pub_key'];
   }
+
   // Only return first value if Stripe is the only/default.
-  if ($form->_paymentProcessor['payment_processor_type'] == 'Stripe') {
+  if (!empty($form->_paymentProcessor) && $form->_paymentProcessor['payment_processor_type'] == 'Stripe') {
     if (isset($form->_paymentProcessor['password'])) {
       return $form->_paymentProcessor['password'];
     }


### PR DESCRIPTION
- Adding form's _submitValues array as additional source when searching for stripe key.
- Setting default payment processor radio button as selected.
- Handling payment_processor and payment_processor_id input fields (depending on CiviCRM version).

Depending on CiviCRM version there is some incosnsistency in CRM/Event/Form/Registration/Register.php class which expect payment_processor input field named differently (for CiviCRM < 4.7 it was 'payment_processor' and for CiviCRM 4.7+ it's 'payment_processor_id'). So we need to handle both cases to make the extension work with various CiviCRM versions.
Currently watchingStop watching