### PR TITLE
BASW-301: Handle Stripe Zero Fee Amounts In JS

### DIFF
--- a/js/civicrm_stripe.js
+++ b/js/civicrm_stripe.js
@@ -163,6 +163,20 @@
           }
         }
       }
+      else {
+        // Skip if total amount is 0
+        if (typeof calculateTotalFee !== 'undefined' && $.isFunction(calculateTotalFee)) {
+          var total_amount_tmp =  calculateTotalFee();
+          if (total_amount_tmp == 0) {
+            return true;
+          }
+        }
+        else if ($form.find('input#total_amount').length) {
+          if ($form.find('input#total_amount').val() == 0) {
+            return true;
+          }
+        }
+      }
       // Disable the submit button to prevent repeated clicks, cache button text, restore if Stripe returns error
       buttonText = $submit.attr('value');
       $submit.prop('disabled', true).attr('value', 'Processing');


### PR DESCRIPTION
**Overview**
This is related to BASW-189. 

When using a price set for an event, CiviCRM generates an error "could not find payment processor" if the fee is set to £0.00 for Stripe.

The fix for BASW-189 was added as a separate extension. Now that extension is to be removed and the fix is added here in this PR.