### PR TITLE
BASW-387: Add 'validatePaymentInstrument' Method To Stripe Payment Class

### DIFF
--- a/CRM/Core/Payment/Stripe.php
+++ b/CRM/Core/Payment/Stripe.php
@@ -669,4 +669,23 @@ class CRM_Core_Payment_Stripe extends CRM_Core_Payment {
   function doTransferCheckout(&$params, $component) {
     CRM_Core_Error::fatal(ts('Use direct billing instead of Transfer method.'));
   }
+
+  /**
+   * Stripe payment instrument validation.
+   *
+   * @param array $values
+   * @param array $errors
+   */
+  public function validatePaymentInstrument($values, &$errors) {
+    $mandatoryFields = $this->getMandatoryFields();
+
+    // set credit_card_number and cvv2 as not required as we have stripe_token
+    $mandatoryFields['credit_card_number']['is_required'] = FALSE;
+    $mandatoryFields['cvv2']['is_required'] = FALSE;
+    CRM_Core_Form::validateMandatoryFields($mandatoryFields, $values, $errors);
+
+    if (empty($_POST['stripe_token'])) {
+      $errors['stripe_token'] = ts('Stripe token not found.');
+    }
+  }
 }


### PR DESCRIPTION
## Overview
New versions of webform_civicrm doesnt work with Stripe payment. It asks for 'credit card number' and 'cvv' number even if both are given.

## Technical details
Previously there was 'Stripe' related code inside webform_civicrm that handled this (Stripe doesnt need 'card number' and 'cvv number' as it has 'stripe token' generated using card details.
Now 'Stripe' related logic are removed from webform_civicrm and it is expected that Stripe extension would handle this using 'validatePaymentInstrument' method in its Payment class.
This PR add this method and after this Stripe payments work without the above issue using new webform_civicrm.

