### PR TITLE
BASW-403: Fix Form Element Selection To Support New Versions Of CiviCRM

### DIFF
--- a/js/civicrm_stripe.js
+++ b/js/civicrm_stripe.js
@@ -67,8 +67,11 @@
       $('form.webform-client-form').addClass('stripe-payment-form');
     }
     else {
-      if (!($('.stripe-payment-form').length)) {
+      if (!($('.stripe-payment-form').length) && $('#crm-container > form').length) {
         $('#crm-container > form').addClass('stripe-payment-form');
+      }
+      else if (!($('.stripe-payment-form').length) && $('#crm-main-content-wrapper > form').length) {
+        $('#crm-main-content-wrapper > form').addClass('stripe-payment-form');
       }
     }
     $form   = $('form.stripe-payment-form');


### PR DESCRIPTION
**Overview**
Stripe payments are failing in BASW when done from within contact view page. The error thrown was 'Stripe.js token not found'. On checking, the JS form selector for selecting a civicrm form was wrong for the civicrm used in BASW. In older versions it works fine.
Initial selector:
$('#crm-container > form')
Selector for new civicrm:
$('#crm-main-content-wrapper > form')