### PR TITLE
BASW-403: Add 'stripe-payment-form' Class For All Cases

### DIFF
--- a/stripe.php
+++ b/stripe.php
@@ -167,9 +167,9 @@ function stripe_civicrm_buildForm($formName, &$form) {
 
   // Add some hidden fields for Stripe.
   if (!$form->elementExists('stripe_token')) {
-    $form->setAttribute('class', $form->getAttribute('class') . ' stripe-payment-form');
     $form->addElement('hidden', 'stripe_token', $stripe_token, array('id' => 'stripe-token'));
   }
+  $form->setAttribute('class', $form->getAttribute('class') . ' stripe-payment-form');
   stripe_add_stripe_js($stripe_key, $form);
 
   // Add email field as it would usually be found on donation forms.


### PR DESCRIPTION
**Overview**
Stripe payments fails in some cases when used within contact view forms.
There is case where the stripe element is not added in 'buildForm' hook. So in that case, the class 'stripe-payment-form' is not added and thus payments fail.
Related PRs: #6 #7 #8 