### PR TITLE
BASW-403: Add UI Blocking And Fix Disabled Button After Form Error

### DIFF
--- a/js/civicrm_stripe.js
+++ b/js/civicrm_stripe.js
@@ -23,7 +23,8 @@
       + '</ul>'
       + '</div>');
 
-      $submit.removeAttr('disabled').attr('value', buttonText);
+      $form.parent().unblock();
+      $submit.removeAttr('disabled').prop('disabled', false).attr('value', buttonText);
 
     }
     else {
@@ -32,7 +33,6 @@
       $form.find("input#stripe-token").val(token);
       $form.find("input#credit_card_number").removeAttr('name');
       $form.find("input#cvv2").removeAttr('name');
-      $submit.prop('disabled', false);
       window.onbeforeunload = null;
       $form.get(0).submit();
     }
@@ -250,7 +250,8 @@
         exp_month:   cc_month,
         exp_year:    cc_year
       }, stripeResponseHandler);
-
+      
+      $form.parent().block();
       return false;
     });
   });


### PR DESCRIPTION
**Overview**
This PR has the fix for the following 2 issues 

Issue 1: Issue found with expiry date field validation. Please check attached screengrab User cannot submit the payment if they missed to enter expiry date at first time they submit the payment. After correcting the date the save button still remains disabled and validation message remains on screen.

Identified this issue is common for all mandatory fields. It’s not being validated correctly.

![ccstripe](https://user-images.githubusercontent.com/36624620/52558659-156c7400-2e19-11e9-9099-9a10da486324.gif)


Issue 2: While the payment is being submitted a loading wheel should be displayed. Currently the loading wheel is not being shown while the form is being submitted.

![ccstripe2](https://user-images.githubusercontent.com/36624620/52558675-25845380-2e19-11e9-81b3-c9ea14217a8e.gif)




