### PR TITLE
BASW-412: Add Validation If Card Number Or CVV Number Are Empty

### DIFF
--- a/js/civicrm_stripe.js
+++ b/js/civicrm_stripe.js
@@ -182,23 +182,25 @@
       }
 
       // card_number not empty validation
-      if (!$form.find("input#credit_card_number").val()) {
-        $form.find("input#credit_card_number").parent().find('.crm-error').remove();
-        $form.find("input#credit_card_number").parent().append('<span class="crm-error msg">Credit-Card Number is required.</span>');
+      var $card_number = $form.find("input#credit_card_number");
+      if (!$card_number.val()) {
+        $card_number.parent().find('.crm-error').remove();
+        $card_number.parent().append('<span class="crm-error msg">Credit-Card Number is required.</span>');
         return false;
       }
       else {
-        $form.find("input#credit_card_number").parent().find('.crm-error.msg').remove();
+        $card_number.parent().find('.crm-error.msg').remove();
       }
 
       // cvv not empty validation
-      if (!$form.find("input#cvv2").val()) {
-        $form.find("input#cvv2").parent().find('.crm-error').remove();
-        $form.find("input#cvv2").parent().append('<span class="crm-error msg">CVV Number is required.</span>');
+      var $cvv = $form.find("input#cvv2");
+      if (!$cvv.val()) {
+        $cvv.parent().find('.crm-error').remove();
+        $cvv.parent().append('<span class="crm-error msg">CVV Number is required.</span>');
         return false;
       }
       else {
-        $form.find("input#cvv2").parent().find('.crm-error.msg').remove();
+        $cvv.parent().find('.crm-error.msg').remove();
       }
 
       // Disable the submit button to prevent repeated clicks, cache button text, restore if Stripe returns error

--- a/js/civicrm_stripe.js
+++ b/js/civicrm_stripe.js
@@ -180,6 +180,27 @@
           }
         }
       }
+
+      // card_number not empty validation
+      if (!$form.find("input#credit_card_number").val()) {
+        $form.find("input#credit_card_number").parent().find('.crm-error').remove();
+        $form.find("input#credit_card_number").parent().append('<span class="crm-error msg">Credit-Card Number is required.</span>');
+        return false;
+      }
+      else {
+        $form.find("input#credit_card_number").parent().find('.crm-error.msg').remove();
+      }
+
+      // cvv not empty validation
+      if (!$form.find("input#cvv2").val()) {
+        $form.find("input#cvv2").parent().find('.crm-error').remove();
+        $form.find("input#cvv2").parent().append('<span class="crm-error msg">CVV Number is required.</span>');
+        return false;
+      }
+      else {
+        $form.find("input#cvv2").parent().find('.crm-error.msg').remove();
+      }
+
       // Disable the submit button to prevent repeated clicks, cache button text, restore if Stripe returns error
       buttonText = $submit.attr('value');
       $submit.prop('disabled', true).attr('value', 'Processing');


### PR DESCRIPTION
**Overview**
Card-number and CVV number are intentionally set to not required in backend as they are used to generate a stripe token and not used after that (I think). But leaving them empty and submitting the form, there is no validation and the form submits and then fails.
This PR adds basic validations for these 2 fields in frontend.