### PR TITLE
BASW-412: Only Validate Cardnumber And CVV If They Exist AndStripe Token Is Not Found

### DIFF
--- a/js/civicrm_stripe.js
+++ b/js/civicrm_stripe.js
@@ -181,9 +181,10 @@
         }
       }
 
+      var $stripe_token = $form.find('input[name="stripe_token"]');
       // card_number not empty validation
       var $card_number = $form.find("input#credit_card_number");
-      if (!$card_number.val()) {
+      if (!$stripe_token.val() && $card_number.length && !$card_number.val()) {
         $card_number.parent().find('.crm-error').remove();
         $card_number.parent().append('<span class="crm-error msg">Credit-Card Number is required.</span>');
         return false;
@@ -194,7 +195,7 @@
 
       // cvv not empty validation
       var $cvv = $form.find("input#cvv2");
-      if (!$cvv.val()) {
+      if (!$stripe_token.val() && $cvv.length && !$cvv.val()) {
         $cvv.parent().find('.crm-error').remove();
         $cvv.parent().append('<span class="crm-error msg">CVV Number is required.</span>');
         return false;


### PR DESCRIPTION
**Overview**
This is related to #11 
I missed testing this with event registration with multiple pages.
We only need validation when stripe_token is not there and the fields exists. For multiple page registration, the second page will have the stripe_token and so validation is not required there.