### PR TITLE
MAE-512: Bump version to 4.7.1+patch.2

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -18,7 +18,7 @@
     <ver>4.6</ver>
     <ver>4.7</ver>
   </compatibility>
-  <comments>PATCH 1</comments>
+  <comments>PATCH 2</comments>
   <comments>http://drastikbydesign.com/blog-entry/civicrm-stripe-payment-processor</comments>
   <civix>
     <namespace>CRM/Stripe</namespace>


### PR DESCRIPTION
Bump version to 4.7.1+patch.2 as part of Membershipextras 4.2.0 release